### PR TITLE
Bug fix: problematic characters in random db password

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ IPAM Configuration:
       - Provisioned CIDRs:
         - `10.0.0.0/18`
 
+## Bug fixes
+- [problematic characters in random db password](https://github.com/JudeQuintana/cloud-infra-lab/pull/9)
+
 ## Begin Demo
 Build:
 - `terraform init`

--- a/rds.tf
+++ b/rds.tf
@@ -1,7 +1,9 @@
 # valid mysql db admin pass
+# dont use $ for issues with variable expansion in the shell on the ec2 host
+# or other potntial problematic characters like ; / "
 resource "random_password" "rds_password" {
   length           = 32
-  override_special = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$%^&*()-_=+[]{}:;,.?"
+  override_special = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#%^&*()-_=+[]{};,.?"
 }
 
 locals {


### PR DESCRIPTION
Every once in a while both `/app1` and `/app2` would show the following error on init.
```
ERROR 1045 (28000): Access denied for user 'admin'@'<ip_address>' (using password: YES)
```

The reason is because the `$` character is allowed in the random db password.

Although, It is a valid mysql rds password but when setting it on the ec2 host as an environment variable it would truncate the password because it's trying to reference another environment variable after the `$`. 

Removing the `$` from being used in the random password at all instead of having to manually escape it.